### PR TITLE
Do not try to uncompress pages that are not compressed

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -122,7 +122,7 @@ func newBlockReader(buf []byte, codec parquet.CompressionCodec, compressedSize i
 	return bytes.NewReader(res), nil
 }
 
-// RegisterBlockCompressor is a function to to register additional block compressors to the package. By default,
+// RegisterBlockCompressor is a function to register additional block compressors to the package. By default,
 // only UNCOMPRESSED, GZIP and SNAPPY are supported as parquet compression algorithms. The parquet file format
 // supports more compression algorithms, such as LZO, BROTLI, LZ4 and ZSTD. To limit the amount of external dependencies,
 // the number of supported algorithms was reduced to a core set. If you want to use any of the other compression

--- a/page_v2_test.go
+++ b/page_v2_test.go
@@ -1,0 +1,56 @@
+package goparquet
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/fraugster/parquet-go/parquet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataReaderV2_Read(t *testing.T) {
+	pageHeader := &parquet.PageHeader{
+		CompressedPageSize:   3,
+		UncompressedPageSize: 3,
+		DataPageHeaderV2: &parquet.DataPageHeaderV2{
+			NumValues:                  5,
+			RepetitionLevelsByteLength: 0,
+			DefinitionLevelsByteLength: 0,
+			NumRows:                    5,
+			Encoding:                   parquet.Encoding_PLAIN,
+			IsCompressed:               false,
+		},
+	}
+
+	mockReader := bytes.NewReader([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	mockDecoder := &mockValuesDecoder{}
+
+	// Create the data page (v2) reader
+	reader := &dataPageReaderV2{
+		ph:          pageHeader,
+		alloc:       newAllocTracker(100),
+		valuesCount: 5,
+		position:    0,
+		fn: func(parquet.Encoding) (valuesDecoder, error) {
+			return mockDecoder, nil
+		},
+	}
+
+	err := reader.read(mockReader, pageHeader, parquet.CompressionCodec_SNAPPY, false)
+	require.NoError(t, err)
+}
+
+type mockValuesDecoder struct {
+	r io.Reader
+}
+
+func (m *mockValuesDecoder) init(reader io.Reader) error {
+	m.r = reader
+	return nil
+}
+
+func (m *mockValuesDecoder) decodeValues(_ []interface{}) (int, error) {
+	// We don't need to implement this
+	return 0, nil
+}


### PR DESCRIPTION
Panther is running [fraugster/parguet-go](https://github.com/fraugster/parquet-go/) in production for some months now ingesting TBs of data.

Some customers reported that they got the following error:
```
snappy: corrupt input
```

After some investigation we can see that in the `read` function of the the V2 DataPage, the flag (already present in `DataPageHeaderV2`) was not checked.

More context: Parquet files - when compressed - are so in the page layer. Parquet supports compression _per page_, (as shown from the `DataPageHeaderV2` `IsCompressed` field, which comes directly from the thrift definition). The library detects the compression type (called `CompressionCodec`) and passes that down to the [`newBlockReader` level](https://github.com/panther-labs/parquet-go/blob/0c50c9da7cd7835c30640c7f51401547bf79d30f/compress.go#L102). However it still needs to check if that specific page is indeed compressed, and that was missing.

FWIW, I doubled check this with [parquet-go/parquet-goparquet-go/parquet-go](https://github.com/parquet-go/parquet-go) and confirmed that they don't try to decompress that.

- [x] Unit tests added
- [x] Full test run (and screenshot)
- [x] Run all unit tests with the race detector on
- [x] Run the linters locally via golangci-lint run

**Ran all the tests with https://github.com/apache/parquet-testing**

![image](https://github.com/panther-labs/parquet-go/assets/777619/873ff0c1-6daa-44da-8e35-3395bb4698b5)

[Note: I can try adding a file into https://github.com/apache/parquet-testing before trying merging this into upstream]

**Ran all unit tests with the race detector on**

![image](https://github.com/panther-labs/parquet-go/assets/777619/403ef582-b4c9-4699-8119-efff0074aabf)

**Added a unit tests**
... that passes with false, but breaks if I do `IsCompressed` => `true` because the input is not snappy