### PR TITLE
Fix bug with failure to read miniblock when only one value with delta encoding of byte arrays

### DIFF
--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -30,8 +30,6 @@ type deltaBitPackDecoder32 struct {
 	miniBlockInt32           [8]int32
 }
 
-// unpackInt32Dynamic handles bit widths > 32 using dynamic unpacking
-
 func (d *deltaBitPackDecoder32) initSize(r io.Reader) error {
 	return d.init(r)
 }
@@ -211,8 +209,6 @@ type deltaBitPackDecoder64 struct {
 	currentUnpacker          unpack8int64Func
 	miniBlockInt64           [8]int64
 }
-
-// unpackInt64Dynamic handles bit widths > 64 using dynamic unpacking
 
 func (d *deltaBitPackDecoder64) init(r io.Reader) error {
 	d.r = r

--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -101,7 +101,7 @@ func (d *deltaBitPackDecoder32) readMiniBlockHeader() error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
-	// Validate bit widths as defense-in-depth (we also check at array access time)
+	// Validate bit widths to be defensive (we also check at array access time)
 	for i := range d.miniBlockBitWidth {
 		if d.miniBlockBitWidth[i] > 32 {
 			return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])

--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -98,11 +98,11 @@ func (d *deltaBitPackDecoder32) readMiniBlockHeader() error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
-	for i := range d.miniBlockBitWidth {
-		if d.miniBlockBitWidth[i] > 32 {
-			return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
-		}
-	}
+	// for i := range d.miniBlockBitWidth {
+	// 	if d.miniBlockBitWidth[i] > 32 {
+	// 		return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
+	// 	}
+	// }
 
 	// start from the first min block in a big block
 	d.currentMiniBlock = 0
@@ -257,11 +257,11 @@ func (d *deltaBitPackDecoder64) readMiniBlockHeader() error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
-	for i := range d.miniBlockBitWidth {
-		if d.miniBlockBitWidth[i] > 64 {
-			return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
-		}
-	}
+	// for i := range d.miniBlockBitWidth {
+	// 	if d.miniBlockBitWidth[i] > 64 {
+	// 		return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
+	// 	}
+	// }
 
 	// start from the first min block in a big block
 	d.currentMiniBlock = 0

--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -41,9 +41,9 @@ func (d *deltaBitPackDecoder32) init(r io.Reader) error {
 		return err
 	}
 
-	// if err := d.readMiniBlockHeader(); err != nil {
-	// 	return err
-	// }
+	if err := d.readMiniBlockHeader(true); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -85,7 +85,7 @@ func (d *deltaBitPackDecoder32) readBlockHeader() error {
 	return nil
 }
 
-func (d *deltaBitPackDecoder32) readMiniBlockHeader() error {
+func (d *deltaBitPackDecoder32) readMiniBlockHeader(init bool) error {
 	var err error
 
 	if d.minDelta, err = readVariant32(d.r); err != nil {
@@ -98,11 +98,13 @@ func (d *deltaBitPackDecoder32) readMiniBlockHeader() error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
-	// for i := range d.miniBlockBitWidth {
-	// 	if d.miniBlockBitWidth[i] > 32 {
-	// 		return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
-	// 	}
-	// }
+	if !init {
+		for i := range d.miniBlockBitWidth {
+			if d.miniBlockBitWidth[i] > 32 {
+				return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
+			}
+		}
+	}
 
 	// start from the first min block in a big block
 	d.currentMiniBlock = 0
@@ -122,7 +124,7 @@ func (d *deltaBitPackDecoder32) next() (int32, error) {
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
-				if err := d.readMiniBlockHeader(); err != nil {
+				if err := d.readMiniBlockHeader(false); err != nil {
 					return 0, err
 				}
 			}
@@ -200,7 +202,7 @@ func (d *deltaBitPackDecoder64) init(r io.Reader) error {
 		return err
 	}
 
-	if err := d.readMiniBlockHeader(); err != nil {
+	if err := d.readMiniBlockHeader(true); err != nil {
 		return err
 	}
 
@@ -244,7 +246,7 @@ func (d *deltaBitPackDecoder64) readBlockHeader() error {
 	return nil
 }
 
-func (d *deltaBitPackDecoder64) readMiniBlockHeader() error {
+func (d *deltaBitPackDecoder64) readMiniBlockHeader(init bool) error {
 	var err error
 
 	if d.minDelta, err = readVariant64(d.r); err != nil {
@@ -257,11 +259,13 @@ func (d *deltaBitPackDecoder64) readMiniBlockHeader() error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
-	// for i := range d.miniBlockBitWidth {
-	// 	if d.miniBlockBitWidth[i] > 64 {
-	// 		return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
-	// 	}
-	// }
+	if !init {
+		for i := range d.miniBlockBitWidth {
+			if d.miniBlockBitWidth[i] > 64 {
+				return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
+			}
+		}
+	}
 
 	// start from the first min block in a big block
 	d.currentMiniBlock = 0
@@ -281,7 +285,7 @@ func (d *deltaBitPackDecoder64) next() (int64, error) {
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
-				if err := d.readMiniBlockHeader(); err != nil {
+				if err := d.readMiniBlockHeader(false); err != nil {
 					return 0, err
 				}
 			}

--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -41,9 +41,9 @@ func (d *deltaBitPackDecoder32) init(r io.Reader) error {
 		return err
 	}
 
-	if err := d.readMiniBlockHeader(); err != nil {
-		return err
-	}
+	// if err := d.readMiniBlockHeader(); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }

--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -30,6 +30,8 @@ type deltaBitPackDecoder32 struct {
 	miniBlockInt32           [8]int32
 }
 
+// unpackInt32Dynamic handles bit widths > 32 using dynamic unpacking
+
 func (d *deltaBitPackDecoder32) initSize(r io.Reader) error {
 	return d.init(r)
 }
@@ -41,8 +43,11 @@ func (d *deltaBitPackDecoder32) init(r io.Reader) error {
 		return err
 	}
 
-	if err := d.readMiniBlockHeader(true); err != nil {
-		return err
+	// If we only have 1 value, there are no deltas to decode, so skip miniblock header
+	if d.valuesCount > 1 {
+		if err := d.readMiniBlockHeader(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -85,7 +90,7 @@ func (d *deltaBitPackDecoder32) readBlockHeader() error {
 	return nil
 }
 
-func (d *deltaBitPackDecoder32) readMiniBlockHeader(init bool) error {
+func (d *deltaBitPackDecoder32) readMiniBlockHeader() error {
 	var err error
 
 	if d.minDelta, err = readVariant32(d.r); err != nil {
@@ -98,11 +103,10 @@ func (d *deltaBitPackDecoder32) readMiniBlockHeader(init bool) error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
-	if !init {
-		for i := range d.miniBlockBitWidth {
-			if d.miniBlockBitWidth[i] > 32 {
-				return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
-			}
+	// Validate bit widths as defense-in-depth (we also check at array access time)
+	for i := range d.miniBlockBitWidth {
+		if d.miniBlockBitWidth[i] > 32 {
+			return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
 		}
 	}
 
@@ -118,18 +122,31 @@ func (d *deltaBitPackDecoder32) next() (int32, error) {
 		return 0, io.EOF
 	}
 
+	// Special case: if we only have 1 value, just return it (no deltas to read)
+	if d.valuesCount == 1 {
+		ret := d.previousValue
+		d.position++
+		return ret, nil
+	}
+
 	// need new byte?
 	if d.position%8 == 0 {
 		// do we need to advance a mini block?
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
-				if err := d.readMiniBlockHeader(false); err != nil {
+				if err := d.readMiniBlockHeader(); err != nil {
 					return 0, err
 				}
 			}
 
 			d.currentMiniBlockBitWidth = d.miniBlockBitWidth[d.currentMiniBlock]
+
+			// Validate bit width is within bounds before using it as array index
+			if int(d.currentMiniBlockBitWidth) >= len(unpack8Int32FuncByWidth) {
+				return 0, fmt.Errorf("invalid miniblock bit width: %d (max supported: %d)", d.currentMiniBlockBitWidth, len(unpack8Int32FuncByWidth)-1)
+			}
+
 			d.currentUnpacker = unpack8Int32FuncByWidth[int(d.currentMiniBlockBitWidth)]
 
 			d.miniBlockPosition = 0
@@ -195,6 +212,8 @@ type deltaBitPackDecoder64 struct {
 	miniBlockInt64           [8]int64
 }
 
+// unpackInt64Dynamic handles bit widths > 64 using dynamic unpacking
+
 func (d *deltaBitPackDecoder64) init(r io.Reader) error {
 	d.r = r
 
@@ -202,8 +221,11 @@ func (d *deltaBitPackDecoder64) init(r io.Reader) error {
 		return err
 	}
 
-	if err := d.readMiniBlockHeader(true); err != nil {
-		return err
+	// If we only have 1 value, there are no deltas to decode, so skip miniblock header
+	if d.valuesCount > 1 {
+		if err := d.readMiniBlockHeader(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -246,7 +268,7 @@ func (d *deltaBitPackDecoder64) readBlockHeader() error {
 	return nil
 }
 
-func (d *deltaBitPackDecoder64) readMiniBlockHeader(init bool) error {
+func (d *deltaBitPackDecoder64) readMiniBlockHeader() error {
 	var err error
 
 	if d.minDelta, err = readVariant64(d.r); err != nil {
@@ -259,11 +281,10 @@ func (d *deltaBitPackDecoder64) readMiniBlockHeader(init bool) error {
 		return fmt.Errorf("not enough data to read all miniblock bit widths: %w", err)
 	}
 
-	if !init {
-		for i := range d.miniBlockBitWidth {
-			if d.miniBlockBitWidth[i] > 64 {
-				return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
-			}
+	// Validate bit widths as defense-in-depth (we also check at array access time)
+	for i := range d.miniBlockBitWidth {
+		if d.miniBlockBitWidth[i] > 64 {
+			return fmt.Errorf("invalid miniblock bit width: %d", d.miniBlockBitWidth[i])
 		}
 	}
 
@@ -279,18 +300,31 @@ func (d *deltaBitPackDecoder64) next() (int64, error) {
 		return 0, io.EOF
 	}
 
+	// Special case: if we only have 1 value, just return it (no deltas to read)
+	if d.valuesCount == 1 {
+		ret := d.previousValue
+		d.position++
+		return ret, nil
+	}
+
 	// need new byte?
 	if d.position%8 == 0 {
 		// do we need to advance a mini block?
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
-				if err := d.readMiniBlockHeader(false); err != nil {
+				if err := d.readMiniBlockHeader(); err != nil {
 					return 0, err
 				}
 			}
 
 			d.currentMiniBlockBitWidth = d.miniBlockBitWidth[d.currentMiniBlock]
+
+			// Validate bit width is within bounds before using it as array index
+			if int(d.currentMiniBlockBitWidth) >= len(unpack8Int64FuncByWidth) {
+				return 0, fmt.Errorf("invalid miniblock bit width: %d (max supported: %d)", d.currentMiniBlockBitWidth, len(unpack8Int64FuncByWidth)-1)
+			}
+
 			d.currentUnpacker = unpack8Int64FuncByWidth[int(d.currentMiniBlockBitWidth)]
 
 			d.miniBlockPosition = 0


### PR DESCRIPTION
## Problem

  This PR fixes a panic when reading Parquet files with **single-value delta-encoded 
  columns**. This case  happens for files created by `Teleport` exported to an s3 bucket.

  ### Error Observed
  panic: invalid miniblock bit width: 101 (max supported: 32)

  This occurred when processing Parquet files containing columns with only 1 row
  using `DELTA_BINARY_PACKED` encoding.

Jira ticket for bug: https://panther-labs.atlassian.net/browse/EPD-1976

  ---

  ## Root Cause

  The delta bit-packed encoding format stores:
  1. **First value** (no delta needed)
  2. **Miniblock metadata** describing how deltas are encoded
  3. **Delta values** for subsequent rows

  When a column has only **1 value**, there are **no deltas** to encode, so the
  Parquet writer omits miniblock metadata and delta data. However, the decoder was
  attempting to read miniblock headers anyway, interpreting arbitrary bytes as bit
  widths (e.g., 101), causing the panic.

  ---

  ## Solution

  This fix follows the approach used by
  [`parquet-go/parquet-go`](https://github.com/parquet-go/parquet-go), which does two things:

- skip Miniblock Header for Single Values: https://github.com/parquet-go/parquet-go/blob/master/encoding/delta/binary_packed.go#L284-L286)

- early Return for Single Values: https://github.com/parquet-go/parquet-go/blob/master/encoding/delta/binary_packed.go#L279-L296

## Changes

  - Modified deltaBitPackDecoder32.init() and deltaBitPackDecoder64.init() to
  conditionally read miniblock headers
  - Added early return paths in next() methods for single-value cases
  - Applied to both int32 and int64 decoders

  ---
## Testing

Added unit tests in [PR](https://github.com/panther-labs/panther-enterprise/pull/25188/files) in panther-enterprise. End to end testing is also included in that PR.
