### PR TITLE
fix miniblock issue with multiple blocks

### DIFF
--- a/deltabp_decoder.go
+++ b/deltabp_decoder.go
@@ -133,6 +133,13 @@ func (d *deltaBitPackDecoder32) next() (int32, error) {
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
+				remainingValues := d.valuesCount - d.position
+				if remainingValues == 1 {
+					// Only 1 value left, no deltas to read, just return the last value
+					ret := d.previousValue
+					d.position++
+					return ret, nil
+				}
 				if err := d.readMiniBlockHeader(); err != nil {
 					return 0, err
 				}
@@ -309,6 +316,13 @@ func (d *deltaBitPackDecoder64) next() (int64, error) {
 		if d.position%d.miniBlockValueCount == 0 {
 			// do we need to advance a big block?
 			if d.currentMiniBlock >= d.miniBlockCount {
+				remainingValues := d.valuesCount - d.position
+				if remainingValues == 1 {
+					// Only 1 value left, no deltas to read, just return the last value
+					ret := d.previousValue
+					d.position++
+					return ret, nil
+				}
 				if err := d.readMiniBlockHeader(); err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
## Problem

The fix https://github.com/panther-labs/parquet-go/pull/2 for `invalid miniblock width` that was deployed did not fix the issue for Kong. The reason is that we only accounted for 1 value in total, but we should have accounted for multiple values but with one block having only one value.

The Kong file had 288 values, which resulted in 257 values for a specific column (due to values being repeated and parquet optimizing storing less values). So there were 2 128-value blocks and the 3rd block had only one value, which essentially meant that there was no miniblock header there, as no deltas were necessary to be calculated.

Ticket: https://panther-labs.atlassian.net/browse/EPD-4321




